### PR TITLE
#include <stdint.h> in TouchScreen.h so we don't have to inside every sketch

### DIFF
--- a/TouchScreen.h
+++ b/TouchScreen.h
@@ -6,6 +6,8 @@
 #ifndef _ADAFRUIT_TOUCHSCREEN_H_
 #define _ADAFRUIT_TOUCHSCREEN_H_
 
+#include <stdint.h>
+
 class Point {
  public:
   Point(void);


### PR DESCRIPTION
I moved the #include <stdint.h> from inside the example.pde to the TouchScreen.h file, so I don't have to write that line inside every sketch that uses the TouchScreen library
