### PR TITLE
Add support to Arduino core for STM32

### DIFF
--- a/TouchScreen.h
+++ b/TouchScreen.h
@@ -14,7 +14,7 @@ typedef volatile uint8_t RwReg;
 #if defined(ARDUINO_STM32_FEATHER)
 typedef volatile uint32 RwReg;
 #endif
-#if defined(ARDUINO_FEATHER52) || defined(ESP32)
+#if defined(ARDUINO_FEATHER52) || defined(ESP32) || defined(ARDUINO_ARCH_STM32)
 typedef volatile uint32_t RwReg;
 #endif
 


### PR DESCRIPTION
Modify definition of RwReg to allow compilation for STM32 platform.
Tested successfully with [Arduino Core for STM32 1.6.1](https://github.com/stm32duino/Arduino_Core_STM32/releases/tag/1.6.1).
