### PR TITLE
Define RwReg for all boards

### DIFF
--- a/TouchScreen.h
+++ b/TouchScreen.h
@@ -10,11 +10,11 @@
 
 #if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) || defined(TEENSYDUINO) || defined(__AVR_ATmega2560__)
 typedef volatile uint8_t RwReg;
-#endif
-#if defined(ARDUINO_STM32_FEATHER)
+#elif defined(ARDUINO_STM32_FEATHER)
 typedef volatile uint32 RwReg;
-#endif
-#if defined(NRF52_SERIES) || defined(ESP32) || defined(ARDUINO_ARCH_STM32)
+#elif defined(NRF52_SERIES) || defined(ESP32) || defined(ARDUINO_ARCH_STM32)
+typedef volatile uint32_t RwReg;
+#else 
 typedef volatile uint32_t RwReg;
 #endif
 


### PR DESCRIPTION
Have a look at the issue #20.
Make sure the library compiles for all board, does not mean it will work... an other solution for my case with an ESP8266 is #21.

Thanks a lot for everything