### PR TITLE
Add ESP8266 to RwReg definition

### DIFF
--- a/TouchScreen.h
+++ b/TouchScreen.h
@@ -12,7 +12,7 @@
 typedef volatile uint8_t RwReg;
 #elif defined(ARDUINO_STM32_FEATHER)
 typedef volatile uint32 RwReg;
-#elif defined(NRF52_SERIES) || defined(ESP32) || defined(ARDUINO_ARCH_STM32)
+#elif defined(NRF52_SERIES) || defined(ESP32) || defined(ESP8266) || defined(ARDUINO_ARCH_STM32)
 typedef volatile uint32_t RwReg;
 #else 
 typedef volatile uint32_t RwReg;


### PR DESCRIPTION
Adds the ESP8266 to the RwReg ifdef as per adafruit#21 but on a clean fork so should merge