### PR TITLE
Added ifdef to allow Teensy 4.1 to work

### DIFF
--- a/TouchScreen.h
+++ b/TouchScreen.h
@@ -7,9 +7,10 @@
 #define _ADAFRUIT_TOUCHSCREEN_H_
 #include <stdint.h>
 
-#if (defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) ||              \
-    defined(TEENSYDUINO) || defined(__AVR_ATmega2560__) ||                     \
-    defined(__AVR_ATmega4809__)) && !defined(__IMXRT1062__)
+#if (defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) ||             \
+     defined(TEENSYDUINO) || defined(__AVR_ATmega2560__) ||                    \
+     defined(__AVR_ATmega4809__)) &&                                           \
+    !defined(__IMXRT1062__)
 typedef volatile uint8_t RwReg;
 #elif defined(ARDUINO_STM32_FEATHER)
 typedef volatile uint32 RwReg;

--- a/TouchScreen.h
+++ b/TouchScreen.h
@@ -7,14 +7,14 @@
 #define _ADAFRUIT_TOUCHSCREEN_H_
 #include <stdint.h>
 
-#if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) ||              \
+#if (defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) ||              \
     defined(TEENSYDUINO) || defined(__AVR_ATmega2560__) ||                     \
-    defined(__AVR_ATmega4809__)
+    defined(__AVR_ATmega4809__)) && !defined(__IMXRT1062__)
 typedef volatile uint8_t RwReg;
 #elif defined(ARDUINO_STM32_FEATHER)
 typedef volatile uint32 RwReg;
 #elif defined(NRF52_SERIES) || defined(ESP32) || defined(ESP8266) ||           \
-    defined(ARDUINO_ARCH_STM32)
+    defined(ARDUINO_ARCH_STM32) || defined(__IMXRT1062__)
 typedef volatile uint32_t RwReg;
 #else
 typedef volatile uint32_t RwReg;


### PR DESCRIPTION
Scope: this allows the code to run on the Teensy 4.1's processor
The TouchScreen.h file was modified to include the `i.MX RT1060` under the 32 bit RwReg

This change would only effect the Teensy 4.1 and other boards which use the `i.MX RT1060`, it should allow others to work with this library as well.

The tests appear to work.