### PR TITLE
Add support for Atmega 1280

### DIFF
--- a/TouchScreen.h
+++ b/TouchScreen.h
@@ -9,6 +9,7 @@
 
 #if (defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) ||             \
      defined(TEENSYDUINO) || defined(__AVR_ATmega2560__) ||                    \
+     defined(__AVR_ATmega1280__) 				||             \
      defined(__AVR_ATmega4809__)) &&                                           \
     !defined(__IMXRT1062__)
 typedef volatile uint8_t RwReg;


### PR DESCRIPTION
- The #if def checks for RwReg were missing a check for ATmega 1280, causing the sketch to fail to build. Added a check for `__AVR_ATmega1280__` and it builds succesfully now. 
