### PR TITLE
adds support for ATMega1284P 

### DIFF
--- a/TouchScreen.h
+++ b/TouchScreen.h
@@ -9,7 +9,7 @@
 
 #if (defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) ||             \
      defined(TEENSYDUINO) || defined(__AVR_ATmega2560__) ||                    \
-     defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega4809__)) &&                                           \
+     defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega4809__)) &&           \
     !defined(__IMXRT1062__)
 typedef volatile uint8_t RwReg;
 #elif defined(ARDUINO_STM32_FEATHER)

--- a/TouchScreen.h
+++ b/TouchScreen.h
@@ -9,7 +9,7 @@
 
 #if (defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) ||             \
      defined(TEENSYDUINO) || defined(__AVR_ATmega2560__) ||                    \
-     defined(__AVR_ATmega4809__)) &&                                           \
+     defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega4809__)) &&                                           \
     !defined(__IMXRT1062__)
 typedef volatile uint8_t RwReg;
 #elif defined(ARDUINO_STM32_FEATHER)


### PR DESCRIPTION
The current typedef of ```RwReg``` is not compiled for ATMega1284P MCUs. With this Pull-Request  the ATMega1284P is added to the list of 8-bit MCUs and so the typedef will be compliled.

Tested this fix with a 3.5'' touch tft and seems to work fine with ATMega1284P MCUs. 