### PR TITLE
Added support for ADCs with other than 10 bit

### DIFF
--- a/TouchScreen.cpp
+++ b/TouchScreen.cpp
@@ -116,7 +116,7 @@ TSPoint TouchScreen::getPoint(void) {
   }
 #endif
 
-  x = (1023 - samples[NUMSAMPLES / 2]);
+  x = (_adcMax - samples[NUMSAMPLES / 2]);
 
   pinMode(_xp, INPUT);
   pinMode(_xm, INPUT);
@@ -152,7 +152,7 @@ TSPoint TouchScreen::getPoint(void) {
   }
 #endif
 
-  y = (1023 - samples[NUMSAMPLES / 2]);
+  y = (_adcMax - samples[NUMSAMPLES / 2]);
 
   // Set X+ to ground
   // Set Y- to VCC
@@ -179,11 +179,11 @@ TSPoint TouchScreen::getPoint(void) {
     rtouch -= 1;
     rtouch *= x;
     rtouch *= _rxplate;
-    rtouch /= 1024;
+    rtouch /= _adcMax+1;
 
     z = rtouch;
   } else {
-    z = (1023 - (z2 - z1));
+    z = (_adcMax - (z2 - z1));
   }
 
   if (!valid) {
@@ -194,12 +194,13 @@ TSPoint TouchScreen::getPoint(void) {
 }
 
 TouchScreen::TouchScreen(uint8_t xp, uint8_t yp, uint8_t xm, uint8_t ym,
-                         uint16_t rxplate = 0) {
+                         uint16_t rxplate, uint8_t adcBits) {
   _yp = yp;
   _xm = xm;
   _ym = ym;
   _xp = xp;
   _rxplate = rxplate;
+  _adcMax = (1 << adcBits) - 1;
 
 #if defined(USE_FAST_PINIO)
   xp_port = portOutputRegister(digitalPinToPort(_xp));
@@ -231,7 +232,7 @@ int TouchScreen::readTouchX(void) {
   pinMode(_xm, OUTPUT);
   digitalWrite(_xm, LOW);
 
-  return (1023 - analogRead(_yp));
+  return (_adcMax - analogRead(_yp));
 }
 /**
  * @brief Read the touch event's Y value
@@ -249,7 +250,7 @@ int TouchScreen::readTouchY(void) {
   pinMode(_ym, OUTPUT);
   digitalWrite(_ym, LOW);
 
-  return (1023 - analogRead(_xm));
+  return (_adcMax - analogRead(_xm));
 }
 /**
  * @brief Read the touch event's Z/pressure value
@@ -282,10 +283,10 @@ uint16_t TouchScreen::pressure(void) {
     rtouch -= 1;
     rtouch *= readTouchX();
     rtouch *= _rxplate;
-    rtouch /= 1024;
+    rtouch /= _adcMax+1;
 
     return rtouch;
   } else {
-    return (1023 - (z2 - z1));
+    return (_adcMax - (z2 - z1));
   }
 }

--- a/TouchScreen.h
+++ b/TouchScreen.h
@@ -50,10 +50,11 @@ public:
    * @param yp Y+ pin. Must be an analog pin
    * @param xm X- pin. Can be a digital pin
    * @param ym Y- pin. Can be a digital pin
-   * @param rx The resistance in ohms between X+ and X- to calibrate pressure
-   * sensing
+   * @param rx The resistance in ohms between X+ and X- to calibrate pressure sensing
+   * @param adcBits for µC with higher resolution ADCs provide the number of bits
    */
-  TouchScreen(uint8_t xp, uint8_t yp, uint8_t xm, uint8_t ym, uint16_t rx);
+  TouchScreen(uint8_t xp, uint8_t yp, uint8_t xm, uint8_t ym, uint16_t rx = 0
+             , uint8_t adcBits = 10);
 
   /**
    * @brief **NOT IMPLEMENTED** Test if the screen has been touched
@@ -68,9 +69,9 @@ public:
   int16_t pressureThreshhold; ///< Pressure threshold for `isTouching`
 
 private:
-  uint8_t _yp, _ym, _xm, _xp;
+  uint8_t  _yp, _ym, _xm, _xp;
   uint16_t _rxplate;
-
+  uint16_t _adcMax; // maximum reading of ADC (= 2^adcBits - 1) 
 #if defined(USE_FAST_PINIO)
   volatile RwReg *xp_port, *yp_port, *xm_port, *ym_port;
   RwReg xp_pin, xm_pin, yp_pin, ym_pin;


### PR DESCRIPTION
Added support for ADCs with other than 10 bir resolution, by adding a optional paramter `adcBits` to constructor.
The constructor updates a member variable `_adcMax` to `2^adcBits-1`. 
Subsequent calculations are now using this variable instead of constants 1023/1024 (which are only correct for 10bit ADCs).

The addition of the _optional_ parameter legacy code will not be affected by the change.