### PR TITLE
Force 10 bit ADC

### DIFF
--- a/examples/touchscreendemo/touchscreendemo.ino
+++ b/examples/touchscreendemo/touchscreendemo.ino
@@ -17,6 +17,9 @@ TouchScreen ts = TouchScreen(XP, YP, XM, YM, 300);
 
 void setup(void) {
   Serial.begin(9600);
+
+  // make sure ADC values are expected 10 bit resolution
+  analogReadResolution(10);
 }
 
 void loop(void) {

--- a/examples/touchscreendemo/touchscreendemo.ino
+++ b/examples/touchscreendemo/touchscreendemo.ino
@@ -18,14 +18,16 @@ TouchScreen ts = TouchScreen(XP, YP, XM, YM, 300);
 void setup(void) {
   Serial.begin(9600);
 
-  // make sure ADC values are expected 10 bit resolution
-  analogReadResolution(10);
+  // 10 bit ADC values are expected by the touch library.
+  // If touch locations seem incorrect, try uncommenting
+  // this line to force 10 bit resolution:
+  // analogReadResolution(10);
 }
 
 void loop(void) {
   // a point object holds x y and z coordinates
   TSPoint p = ts.getPoint();
-  
+
   // we have some minimum pressure we consider 'valid'
   // pressure of 0 means no pressing!
   if (p.z > ts.pressureThreshhold) {

--- a/examples/touchscreendemoshield/touchscreendemoshield.ino
+++ b/examples/touchscreendemoshield/touchscreendemoshield.ino
@@ -21,6 +21,9 @@ TouchScreen ts = TouchScreen(XP, YP, XM, YM, 300);
 
 void setup(void) {
   Serial.begin(9600);
+
+  // make sure ADC values are expected 10 bit resolution
+  analogReadResolution(10);
 }
 
 void loop(void) {

--- a/examples/touchscreendemoshield/touchscreendemoshield.ino
+++ b/examples/touchscreendemoshield/touchscreendemoshield.ino
@@ -22,14 +22,16 @@ TouchScreen ts = TouchScreen(XP, YP, XM, YM, 300);
 void setup(void) {
   Serial.begin(9600);
 
-  // make sure ADC values are expected 10 bit resolution
-  analogReadResolution(10);
+  // 10 bit ADC values are expected by the touch library.
+  // If touch locations seem incorrect, try uncommenting
+  // this line to force 10 bit resolution:
+  // analogReadResolution(10);
 }
 
 void loop(void) {
   // a point object holds x y and z coordinates
   TSPoint p = ts.getPoint();
-  
+
   // we have some minimum pressure we consider 'valid'
   // pressure of 0 means no pressing!
   if (p.z > MINPRESSURE && p.z < MAXPRESSURE) {


### PR DESCRIPTION
Simple fix for #39 and an alternate to #43.

No change to library code. Only examples are changed to add a setting for ADC resolution to force 10 bit to be used.
